### PR TITLE
CRaCMinPid works with Podman Alpine

### DIFF
--- a/checkpoint_container/crac_alpine_jre.Dockerfile
+++ b/checkpoint_container/crac_alpine_jre.Dockerfile
@@ -28,5 +28,9 @@ RUN \
   chmod 755 /app/start.sh
 
 WORKDIR /app
-ENTRYPOINT ["/sbin/tini", "--"]
+# There is a possible bug in Podman - ENTRYPOINT is reset by the following command:
+#    $ podman container commit --change="CMD [ 'whatever' ]" ...
+# This issue causes PIDs shifting in restore container.
+# So making it working with both Podman and Docker by commenting out the line below.
+# ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["./start.sh"]

--- a/checkpoint_container/start.sh
+++ b/checkpoint_container/start.sh
@@ -1,14 +1,8 @@
 #!/bin/sh
 
-# invoke a dummy command 1000 times so the Java process can start with PID/TIDs >1000, which on restore are very likely to be free
-for i in $(seq 1000)
-do
-    /bin/true
-done
-
 # In unprivileged mode we can't easily re-attach std out/err/in to terminals, we need to tie stdin to /dev/null and redirect stdout and stderr to files, 
 # and those files need to be present at the same path on restore. The easiest solution is to just dump them to the checkpoint data dir.
 # java $JAVA_OPTS $JAVA_OPTS_EXTRA -jar app.jar 0</dev/null 1>/app/checkpoint/stdout 2>/app/checkpoint/stderr
 
-java $JAVA_OPTS $JAVA_OPTS_EXTRA -jar app.jar
+java -XX:CRaCMinPid=5000 $JAVA_OPTS $JAVA_OPTS_EXTRA -jar app.jar
 # java $JAVA_OPTS $JAVA_OPTS_EXTRA -jar app.jar 0</dev/null 1>/app/checkpoint/stdout 2>/app/checkpoint/stderr


### PR DESCRIPTION
This PR fixes the problem with CRaCMinPid option on Alpine, mentioned in the article [here](https://github.com/fipro78/osgi-jakartars/blob/444f95a1465ded8893736f239401cd0ef1e3cb76/tutorials/cracin_your_osgi_application.md?plain=1#L1153):

> Starting the application in the container with the additional JVM flag on an Ubuntu base image, the PID is 513 and the restore works fine. Trying the same on an Alpine base image results in 
> `Error (criu/pstree.c:404): Current gid 8 intersects with pid (1) in images`

Checking the result on my Windows:

```
user@COMPUTER /cygdrive/d/work/osgi-jakartars/checkpoint_container
$ ./build_crac.bat podman alpine_jre
...

user@COMPUTER /cygdrive/d/work/osgi-jakartars/checkpoint_container
$./run_crac.bat podman alpine_jre
...

user@COMPUTER /cygdrive/d/work 
$ podman container exec -it crac_alpine_jre_restore sh -c 'ps aux'
PID   USER     TIME  COMMAND
    1 root      0:00 /opt/jdk/lib/criuengine restorewait
   24 root      0:00 ps aux
 5001 root      0:01 java -XX:CRaCMinPid=5000 -XX:CRaCCheckpointTo=/app/checkpoint -Djdk.crac.resource-policies=/app/fd_policies.yaml -
```

The restored process is running on Alpine with PID=5001 that is the result of applying `-XX:CRaCMinPid=5000` option on checkpont in `checkpoint_container/start.sh` file.

The problem with ENTRYPOINT on Podman can be fixed in different ways, so I've chosen the simplest one to illustrate the result.

With this fix, I've got the same results for both Docker/Podman Ubuntu/Alpine. Here is the example of my logs for different combinations:

```
$ podman container exec -it crac_ubuntu_jre_restore sh -c 'ps aux'
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.3  0.0   2776   936 ?        Ss   16:45   0:00 /opt/jdk/lib/criuengine restorewait
root          19  0.0  0.0   2892   996 pts/0    Ss+  16:45   0:00 sh -c ps aux
root          20  0.0  0.0   7064  1536 pts/0    R+   16:45   0:00 ps aux
root        5001 11.1  0.6 11337424 113204 ?     Sl   16:45   0:00 java -XX:CRaCMinPid=5000 -XX:CRaCCheckpointTo=/app/checkpoint -Djdk.c
```

```
$ docker container exec -it crac_ubuntu_jre_restore sh -c 'ps aux'
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  1.0  0.0   2776  1000 ?        Ss   16:47   0:00 /opt/jdk/lib/criuengine restorewait
root        20  0.0  0.0   2892   952 pts/0    Ss+  16:47   0:00 sh -c ps aux
root        26  0.0  0.0   7064  1564 pts/0    R+   16:47   0:00 ps aux
root      5001  6.3  0.4 11537116 74692 ?      Sl   16:47   0:00 java -XX:CRaCMinPid=5000 -XX:CRaCCheckpointTo=/app/checkpoint -Djdk.cra
```
```
$ docker container exec -it crac_alpine_jre_restore sh -c 'ps aux'
PID   USER     TIME  COMMAND
    1 root      0:00 /opt/jdk/lib/criuengine restorewait
   23 root      0:00 ps aux
 5001 root      0:00 java -XX:CRaCMinPid=5000 -XX:CRaCCheckpointTo=/app/checkpoint -Djdk.crac.resource-policies=/app/fd_policies.yaml -
```

BTW Crac docs are updated now, and you may want to try the example from CRaCMinPid docs https://docs.azul.com/core/crac/crac-debugging#using-cracminpid-option on different platforms before integrating Crac into the app, to check if Java run with PID=1, and test CRaCMinPid option.
